### PR TITLE
Kernel linearization support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,9 @@ F90_OPTS += $(F90_MOD_DIR_OPT) $(INC_DIR)
 PROGRAMS := turbogap
 
 
-SRC := splines.f90 types.f90 neighbors.f90 gap.f90 vdw.f90		\
+SRC := splines.f90 types.f90 neighbors.f90 kernel_linearization.f90 gap.f90 vdw.f90		\
 	local_properties.f90 exp_utils.f90  xyz.f90 md.f90 mc.f90 read_files.f90	\
-	gap_interface.f90 mpi.f90 exp_interface.f90 kernel_linearization.f90
+	gap_interface.f90 mpi.f90 exp_interface.f90
 
 SRC_TP_BT := resamplekin.f90
 SRC_ST := soap_turbo_functions.f90 soap_turbo_radial.f90 soap_turbo_angular.f90 \

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ PROGRAMS := turbogap
 
 SRC := splines.f90 types.f90 neighbors.f90 gap.f90 vdw.f90		\
 	local_properties.f90 exp_utils.f90  xyz.f90 md.f90 mc.f90 read_files.f90	\
-	gap_interface.f90 mpi.f90 exp_interface.f90
+	gap_interface.f90 mpi.f90 exp_interface.f90 kernel_linearization.f90
 
 SRC_TP_BT := resamplekin.f90
 SRC_ST := soap_turbo_functions.f90 soap_turbo_radial.f90 soap_turbo_angular.f90 \

--- a/src/gap_interface.f90
+++ b/src/gap_interface.f90
@@ -48,7 +48,8 @@ module gap_interface
                           write_soap, write_derivatives, compress_soap, &
                           compress_P_nonzero, compress_P_i, compress_P_j, compress_P_el, &
                           delta, zeta, central_species, &
-                          xyz_species, xyz_species_supercell, alphas, Qs, all_atoms, &
+                          xyz_species, xyz_species_supercell, alphas, Qs, &
+                          do_linear_energies, do_linear_forces, all_atoms, &
                           which_atom, indices, soap, soap_cart_der, der_neighbors, der_neighbors_list, &
                           has_local_properties, n_local_properties, local_property_models,  &
                           energies0, forces0, local_properties0,&
@@ -74,7 +75,7 @@ module gap_interface
                            & local_property_indexes(:), this_i_beg, this_i_end, this_j_beg, this_j_end, lp_index
     logical, intent(in) :: do_timing, do_derivatives, compress_soap,&
          & do_forces, do_prediction, all_atoms, write_soap,&
-         & write_derivatives, has_local_properties
+         & write_derivatives, has_local_properties, do_linear_energies, do_linear_forces
     character*64, intent(in) :: basis
     character*32, intent(in) :: scaling_mode
     character*8, intent(in) :: xyz_species(:), xyz_species_supercell(:), species_types(:)
@@ -320,6 +321,7 @@ module gap_interface
       if( n_sites > 0 )then
         call get_soap_energy_and_forces(soap, soap_cart_der, alphas, delta, zeta, 0.d0, Qs, &
                                         n_neigh, neighbors_list, xyz, do_forces, do_timing, &
+                                        do_linear_energies, do_linear_forces, &
                                         energies, forces, virial)
       end if
 

--- a/src/kernel_linearization.f90
+++ b/src/kernel_linearization.f90
@@ -1,0 +1,347 @@
+! Note that this module only makes sense for zeta integer
+
+module kernel_linearization
+
+  contains
+
+!**************************************************************************
+!
+! This function checks whether using a linearized kernel is faster than the
+! usual kernel.
+!
+  function check_kernel_vs_linear(zeta, n_sites, n_sparse, n_soap, n_linear, &
+                                  do_timing) result(do_linear)
+
+    implicit none
+
+    integer, intent(in) :: zeta, n_sparse, n_soap, n_sites, n_linear
+    real*8 :: alphas(1:n_sparse), alphas_linear(1:n_linear), E(1:n_sites)
+    real*8 :: Qs(1:n_soap, 1:n_sparse), desc(1:n_soap, 1:n_sites), &
+              kernels(1:n_sites, 1:n_sparse), kernels_copy(1:n_sites, 1:n_sparse), &
+              desc_copy(1:n_sites, 1:n_soap), desc_linear(1:n_sites, 1:n_linear)
+    real*8 :: t1, t2, t_kernel, t_linear
+    logical :: do_linear, do_timing
+
+    call random_number(alphas)
+    call random_number(alphas_linear)
+    call random_number(Qs)
+    call random_number(desc)
+    desc_linear = 0.d0
+    kernels = 0.d0
+    do_linear = .false.
+
+    call cpu_time(t1)
+    call dgemm("t", "n", n_sites, n_sparse, n_soap, 1.d0, desc, n_soap, &
+                Qs, n_soap, 0.d0, kernels, n_sites)
+    kernels_copy = kernels**zeta
+    E = matmul(kernels_copy, alphas)
+    call cpu_time(t2)
+    t_kernel = t2 - t1
+
+    call cpu_time(t1)
+    desc_copy = transpose(desc)
+    call get_linearized_desc(zeta, desc_copy, desc_linear)
+    E = matmul(desc_linear, alphas_linear)
+    call cpu_time(t2)
+    t_linear = t2 - t1
+
+    if( do_timing )then
+      write(*,*) "Time energies (usual kernel): ", t_kernel
+      write(*,*) "Time energies (linearized kernel): ", t_linear
+    end if
+
+!   Add forces check, since it might change the decision chain
+    if( t_linear < t_kernel )then
+      do_linear = .true.
+    else
+!     Check here if forces would be faster
+      do_linear = check_forces_kernel_vs_lineal(zeta, n_sites, n_sparse, n_soap, &
+                                                n_linear, do_timing)
+    end if
+
+  end function
+!**************************************************************************
+
+!**************************************************************************
+!
+! This function checks whether using a linearized kernel is faster than the
+! usual kernel when calculating forces.
+!
+  function check_forces_kernel_vs_linear(zeta, n_sites, n_sparse, n_soap, &
+                                         n_linear, do_timing) result(do_linear)
+
+    implicit none
+
+    integer, intent(in) :: zeta, n_sparse, n_soap, n_sites, n_linear
+    integer :: n_neigh(1:n_sites)
+    real*8 :: alphas(1:n_sparse), this_Qss(1:n_soap), n_neigh(1:n_sites), this_force(1:3)
+    real*8 :: Qs(1:n_soap, 1:n_sparse), Qs_copy(1:n_soap, 1:n_sparse), Qss(1:n_sites, 1:n_soap), &
+              kernels(1:n_sites, 1:n_sparse), kernels_der(1:n_sites, 1:n_sparse), &
+              desc(1:n_sites, 1:n_soap), desc_linear(1:n_sites, 1:n_linear), &
+              Ms_linear(1:n_soap,1:n_linear), kernels_linear(1:n_soap, 1:n_sites)
+    real*8, allocatable :: desc_der(:,:,:), F(:,:)
+    integer :: nn = 100, n_atom_pairs, l, i, j, k
+    real*8 :: t1, t2, t_kernel, t_linear
+    logical :: do_linear, do_timing
+
+    do_linear = .false.
+
+!   Initialize arrays for kernel calculation of forces
+    call random_number(alphas)
+    call random_number(Qs)
+    call random_number(kernels)
+    Qss = 0.d0
+    Qs_copy = Qs
+
+    call random_number(n_neigh0)
+    n_atom_pairs = 0
+    do i = 1, n_sites
+      n_neigh(i) = 1 + floor(nn*n_neigh0(i))
+      n_atom_pairs = n_atom_pairs + n_neigh(i)
+    end do
+    allocate( desc_der(1:3, 1:n_soap, 1:n_atom_pairs) )
+    allocate( F(1:3, 1:n_atom_pairs) )
+    call random_number(desc_der)
+    F = 0.d0
+
+!   Performance for the usual kernel implementation of forces
+    t_kernel = 0.d0
+    call cpu_time(t1)
+    kernels_der = kernels**(zeta - 1)
+    if( n_sites < n_soap )then
+      do i = 1, n_sites
+        kernels_der(i,:) = kernels_der(i,:)*alphas(:)
+      end do
+    else
+      do i = 1, n_soap
+        Qs_copy(i,:) = Qs(i,:)*alphas(:)
+      end do
+    end if
+    if( n_sites > 0 )then
+      call dgemm("n", "t", n_sites, n_soap, n_sparse, 1.d0, kernels_der, n_sites, &
+                Qs, n_soap, 0.d0, Qss, n_sites)
+    end if
+
+    if( do_timing )then
+      call cpu_time(t2)
+      t_kernel = t2 - t1 
+      write(*,*) "Time forces (usual kernel part 1): ", t_kernel
+      call cpu_time(t1)
+    end if
+
+    l = 0
+    do i = 1, n_sites
+      this_Qss = Qss(i, 1:n_soap)
+      do j = 1, n_neigh(i)
+        l = l + 1
+        do k = 1, 3
+          this_force(k) = dot_product(this_Qss, desc_der(k, 1:n_soap, l))
+          F(k, l) = F(k, l) + this_force(k)
+        end do
+      end do
+    end do
+    call cpu_time(t2)
+    t_kernel = t_kernel + (t2 - t1)
+
+    if( do_timing )then
+      write(*,*) "Time forces (usual kernel part 2): ", t2 - t1
+      write(*,*) "Time forces (usual kernel): ", t_kernel
+    end if
+
+!   Initialize arrays for linearized calculation of forces
+    call random_number(Qs_linear)
+    call random_number(desc)
+    desc_linear = 0.d0
+
+!   Time the performance of linearized implementation of forces
+    call cpu_time(t1)
+    call get_linearized_desc(zeta, desc, desc_linear)
+    call dgemm('n', 't', n_soap, n_sites, n_linear, 1.d0, Ms_linear, n_soap, &
+               desc_linear, n_sites, 0.d0, kernels_linear, n_soap)
+    l = 1
+    do i = 1, n_sites
+      this_Qss = kernels_linear(1:n_soap, i)
+      do j = 1, n_neigh(i)
+        do k = 1, 3
+          this_forces(k) = dot_product(this_Qss, desc_der(k, 1:n_soap, l))
+          F(k, l) = F(k, l) + this_force(k)
+        end do
+        l = l + 1
+      end do
+    end do
+    call cpu_time(t2)
+    t_linear = t2 - t1
+
+    if( do_timing )then
+      write(*,*) "Time forces (linearized kernel): ", t_linear
+    end if
+
+    if( t_linear < t_kernel )then
+      do_linear = .true.
+    end if
+
+    deallocate( F, desc_der )
+
+  end function
+!**************************************************************************
+
+
+!**************************************************************************
+!
+! This subroutine gives the linearized version of a vector v**zeta,
+! for zeta integer. That is, the original vector v = (q1, ..., qN) 
+! is mapped to a linear model based on its multinomial expansion, 
+! returning
+!               v_lin = (q1_lin, ..., qN'_lin) 
+! where
+!             N' = (zeta + N - 1) ··· N / (zeta)!
+! and
+!     qi_lin = (zeta)! · prod_{k=1}^N qk^alpha_k / (alpha_k)!
+! for i --> (alpha_1, ..., alpha_k) such that sum_k alpha_k = zeta
+!
+! It is possible to pass a matrix of vectors V, to get V_lin, with
+! V**T = (v1 v2 ... ) and V_lin**T = (v1_lin v2_lin ... )
+!
+! NOTE: current implementation only works for zeta == 2, 3 !!!!!!!!!!!
+!
+  subroutine get_linearized_desc(zeta, V, V_lin)
+
+    implicit none
+
+    integer, intent(in) :: zeta
+    real*8, intent(in) :: V(:,:)
+    integer :: n, m, i, j, k, l
+    real*8, intent(out) :: V_lin(:,:)
+
+    m = size(V, 1) ! this dim. does not change
+    n = size(V, 2)
+
+!   check that V_lin has the right size!!!!
+
+    V_lin(1:m, 1:n) = V**zeta
+
+!   this implementation is slow in fortran (better to take whole rows than columns)!!!
+!   but I would need to transpose the matrices then (given how we allocate them in TurboGAP)
+    if( zeta == 2 )then
+      k = n + 1
+      do i = 1, n
+        do j = i + 1, n
+          V_lin(1:m, k) = 2.d0 * V(1:m, i) * V(1:m, j)
+          k = k + 1
+        end do
+      end do
+    else if( zeta == 3 )then
+      k = n + 1
+      do i = 1, n
+        do j = i + 1, n
+          V_lin(1:m, k) = 3.d0 * V(1:m, i)**2 * V(1:m, j)
+          V_lin(1:m, k + 1) = 3.d0 * V(1:m, i) * V(1:m, j)**2
+          k = k + 2
+        end do
+      end do
+    else if( zeta == 3 )then
+      k = n + 1
+      do i = 1, n
+        do j = i + 1, n
+          V_lin(1:m, k) = 3.d0 * V(1:m, i)**2 * V(1:m, j)
+          V_lin(1:m, k + 1) = 3.d0 * V(1:m, i) * V(1:m, j)**2
+          k = k + 2
+          do l = j + 1, n
+            V_lin(1:m, k) = 6.d0 * V(1:m, i) * V(1:m, i) * V(1:m, l)
+            k = k + 1
+          end do
+        end do
+      end do
+    end if
+
+  end subroutine
+!**************************************************************************
+
+!**************************************************************************
+!
+! This function computes the linearized sparse contribution for energies,
+! given by
+!                 alphas_linear = Qs_linear · alphas
+! For forces, use get_linearized_sparse_forces() 
+!
+  function get_linearized_sparse(zeta, alphas, Qs) result(alphas_linear)
+
+    implicit none
+
+    integer, intent(in) :: zeta
+    real*8, intent(in) :: alphas(:), Qs(:,:)
+    integer :: n_soap, n_sparse, n_linear
+    real*8, allocatable :: Qs_linear(:,:)
+    real*8, allocatable, intent(out) :: alphas_linear(:)
+
+    n_soap = size(Qs, 2) ! here we assume Qs(1:n_sparse, 1:n_soap), I could check it using alphas size
+    n_sparse = size(alphas)
+!   Size of the linearized model
+    n_linear = 1
+    do i = 1, zeta
+      n_linear = n_linear*(n_soap + i - 1)/i
+    end do
+
+!   Allocate arrays
+    allocate( alphas_linear(1:n_linear) )
+    allocate( Qs_linear(1:n_sparse, 1:n_linear) )
+    alphas_linear = 0.d0
+    Qs_linear = 0.d0
+
+!   Get alphas_linear
+    call get_linearized_desc(zeta, Qs, Qs_linear)
+    alphas_linear = matmul(alphas, Qs_linear)
+
+    deallocate( Qs_linear )
+
+  end function
+!**************************************************************************
+
+!**************************************************************************
+!
+! This function computes the linearized sparse contribution for forces, 
+! given in this case by the matrix
+!                 Ms_linear = (Qs * diag(alphas)) · (Qs_linear)**T
+! Note that Qs_linear is computed here using zeta' = zeta - 1
+!
+  function get_linearized_sparse_forces(zeta, alphas, Qs) result(Ms_linear)
+
+    implicit none
+
+    integer, intent(in) :: zeta
+    real*8, intent(in) :: alphas(:), Qs(:,:)
+    integer :: zeta0, n_soap, n_sparse, n_linear, i
+    real*8, allocatable :: Qss(:,:), Qs_linear(:,:)
+    real*8, allocatable :: Ms_linear(:,:)
+
+    n_soap = size(Qs, 2) ! here we assume Qs(1:n_sparse, 1:n_soap)
+    n_sparse = size(alphas)
+!   Size of the linearized model
+    zeta0 = zeta - 1
+    n_linear = 1
+    do i = 1, zeta0
+      n_linear = n_linear*(n_soap + i - 1)/i
+    end do
+
+!   Initialize arrays
+    allocate( Ms_linear(1:n_soap, 1:n_linear) )
+    allocate( Qs_linear(1:n_sparse, 1:n_linear) )
+    allocate( Qss(1:n_sparse, 1:n_soap) )
+    Ms_linear = 0.d0
+    Qs_linear = 0.d0
+   
+!   Get the linearized contribution
+    do i=1, n_soap
+      Qss(1:n_sparse, i) = alphas * Qs(1:n_sparse, i)
+    end do
+    call get_linearized_desc(zeta0, Qs, Qs_linear)
+    call dgemm('t','n', n_soap, n_linear, n_sparse, 1.d0, Qss, n_linear, Qs_linear, &
+                n_linear, 0.d0, Ms_linear, n_soap)
+
+    deallocate( Qs_linear, Qss )
+
+  end function
+!**************************************************************************
+
+
+end module

--- a/src/read_files.f90
+++ b/src/read_files.f90
@@ -2382,7 +2382,7 @@ end if
             else if( keyword == "desc_sparse" )then
               backspace(10)
               read(10, *, iostat=iostatus) cjunk, cjunk, soap_turbo_hypers(n_soap_turbo)%file_desc
-              if( params%kernel_linearization )then
+              if( params%kernel_linearization .and. params%do_forces )then
                 file_desc_linear = trim(soap_turbo_hypers(n_soap_turbo)%file_desc) // "_linear.dat"
                 inquire(file=file_desc_linear, exist=has_desc_linear)
                 if( has_desc_linear )then

--- a/src/read_files.f90
+++ b/src/read_files.f90
@@ -2531,12 +2531,21 @@ end if
           end do
 !         Read the sparse set information
           if( do_prediction )then
-            call read_alphas_and_descriptors(soap_turbo_hypers(n_soap_turbo)%file_desc, &
-                                             soap_turbo_hypers(n_soap_turbo)%file_alphas, &
-                                             soap_turbo_hypers(n_soap_turbo)%n_sparse, &
-                                             "soap_turbo", soap_turbo_hypers(n_soap_turbo)%alphas, &
-                                             soap_turbo_hypers(n_soap_turbo)%Qs, &
-                                             soap_turbo_hypers(n_soap_turbo)%cutoff)
+            if( soap_turbo_hypers(n_soap_turbo)%do_linear_forces )then
+              call read_alphas_and_descriptors(soap_turbo_hypers(n_soap_turbo)%file_desc, &
+                                               soap_turbo_hypers(n_soap_turbo)%file_alphas, &
+                                               soap_turbo_hypers(n_soap_turbo)%n_sparse, &
+                                               "soap_turbo_linear", soap_turbo_hypers(n_soap_turbo)%alphas, &
+                                               soap_turbo_hypers(n_soap_turbo)%Qs, &
+                                               soap_turbo_hypers(n_soap_turbo)%cutoff)
+            else
+              call read_alphas_and_descriptors(soap_turbo_hypers(n_soap_turbo)%file_desc, &
+                                               soap_turbo_hypers(n_soap_turbo)%file_alphas, &
+                                               soap_turbo_hypers(n_soap_turbo)%n_sparse, &
+                                               "soap_turbo", soap_turbo_hypers(n_soap_turbo)%alphas, &
+                                               soap_turbo_hypers(n_soap_turbo)%Qs, &
+                                               soap_turbo_hypers(n_soap_turbo)%cutoff)
+            end if
             ! Commenting this out as it will be subsumed into local property prediction
             ! if( soap_turbo_hypers(n_soap_turbo)%has_vdw )then
             !    call read_alphas_and_descriptors(soap_turbo_hypers(n_soap_turbo)%file_vdw_desc, &

--- a/src/turbogap.f90
+++ b/src/turbogap.f90
@@ -484,15 +484,17 @@ program turbogap
              local_property_labels, local_property_labels_temp, local_property_labels_temp2, local_property_indexes, &
              valid_vdw, vdw_lp_index, core_be_lp_index, valid_xps, xps_idx )
 
-        write(*,*)'                                       |'
-        write(*,*)' Irreducible local properties:         |'
-        do i = 1, params%n_local_properties
-           write(*,'(A41)') trim( local_property_labels(i) ) // ' |'
-        end do
+        if( params%n_local_properties > 0)then
+           write(*,*)'                                       |'
+           write(*,*)' Irreducible local properties:         |'
+           do i = 1, params%n_local_properties
+              write(*,'(A41)') trim( local_property_labels(i) ) // ' |'
+           end do
 
-        allocate( params%write_local_properties(1:params%n_local_properties) )
-        params%write_local_properties = .true.
 
+           allocate( params%write_local_properties(1:params%n_local_properties) )
+           params%write_local_properties = .true.
+        end if
 
 
 #ifdef _MPIF90
@@ -650,10 +652,7 @@ program turbogap
         dim = soap_turbo_hypers(i)%dim
         n_nonzero = soap_turbo_hypers(i)%compress_P_nonzero
         call mpi_bcast(soap_turbo_hypers(i)%alphas(1:n_sparse), n_sparse, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-        if( soap_turbo_hypers(i)%file_desc == "kernel_linearization" )then
-          call mpi_bcast(soap_turbo_hypers(i)%Qs(1:1, 1:1), 1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-        else
-          call mpi_bcast(soap_turbo_hypers(i)%Qs(1:dim, 1:n_sparse), n_sparse*dim, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+        call mpi_bcast(soap_turbo_hypers(i)%Qs(1:dim, 1:n_sparse), n_sparse*dim, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
         end if
         call mpi_bcast(soap_turbo_hypers(i)%delta, 1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
         call mpi_bcast(soap_turbo_hypers(i)%zeta, 1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
@@ -1542,7 +1541,9 @@ program turbogap
                    soap_turbo_hypers(i)%compress_P_el, &
                    soap_turbo_hypers(i)%delta, soap_turbo_hypers(i)%zeta, soap_turbo_hypers(i)%central_species, &
                    xyz_species(this_i_beg:this_i_end), xyz_species_supercell, soap_turbo_hypers(i)%alphas, &
-                   soap_turbo_hypers(i)%Qs, params%all_atoms, params%which_atom, indices, soap, soap_cart_der, &
+                   soap_turbo_hypers(i)%Qs, soap_turbo_hypers(n_soap_turbo)%do_linear_energies, &
+                   soap_turbo_hypers(n_soap_turbo)%do_linear_forces, &
+                   params%all_atoms, params%which_atom, indices, soap, soap_cart_der, &
                    der_neighbors, der_neighbors_list, &
                    & soap_turbo_hypers(i)%has_local_properties,&
                    & soap_turbo_hypers(i)%n_local_properties,&

--- a/src/turbogap.f90
+++ b/src/turbogap.f90
@@ -1704,13 +1704,13 @@ program turbogap
                     n_sites_this = size(der_neighbors,1)
                     n_soap = size(soap_cart_der, 2)
                     n_atom_pairs = size(der_neighbors_list,1)
-                    write(10, *) n_sites, n_soap, n_atom_pairs
+                    write(10, *) n_sites_this, n_soap, n_atom_pairs
                     k = 1
                     k2 = 0
                     do i2 = 1, n_sites_this
                        write(10,*) der_neighbors_list(k), der_neighbors(i2), der_neighbors_list(k:k+der_neighbors(i2)-1)
-                       k = k + der_neighbors(i)
-                       do j = 1, der_neighbors(i)
+                       k = k + der_neighbors(i2)
+                       do j = 1, der_neighbors(i2)
                           k2 = k2 + 1
                           write(10, '(*(ES24.15))') soap_cart_der(1, 1:n_soap, k2)
                           write(10, '(*(ES24.15))') soap_cart_der(2, 1:n_soap, k2)

--- a/src/turbogap.f90
+++ b/src/turbogap.f90
@@ -650,7 +650,11 @@ program turbogap
         dim = soap_turbo_hypers(i)%dim
         n_nonzero = soap_turbo_hypers(i)%compress_P_nonzero
         call mpi_bcast(soap_turbo_hypers(i)%alphas(1:n_sparse), n_sparse, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-        call mpi_bcast(soap_turbo_hypers(i)%Qs(1:dim, 1:n_sparse), n_sparse*dim, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+        if( soap_turbo_hypers(i)%file_desc == "kernel_linearization" )then
+          call mpi_bcast(soap_turbo_hypers(i)%Qs(1:1, 1:1), 1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+        else
+          call mpi_bcast(soap_turbo_hypers(i)%Qs(1:dim, 1:n_sparse), n_sparse*dim, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
+        end if
         call mpi_bcast(soap_turbo_hypers(i)%delta, 1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
         call mpi_bcast(soap_turbo_hypers(i)%zeta, 1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
         call mpi_bcast(soap_turbo_hypers(i)%basis, 64, MPI_CHARACTER, 0, MPI_COMM_WORLD, ierr)

--- a/src/turbogap.f90
+++ b/src/turbogap.f90
@@ -653,7 +653,6 @@ program turbogap
         n_nonzero = soap_turbo_hypers(i)%compress_P_nonzero
         call mpi_bcast(soap_turbo_hypers(i)%alphas(1:n_sparse), n_sparse, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
         call mpi_bcast(soap_turbo_hypers(i)%Qs(1:dim, 1:n_sparse), n_sparse*dim, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
-        end if
         call mpi_bcast(soap_turbo_hypers(i)%delta, 1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
         call mpi_bcast(soap_turbo_hypers(i)%zeta, 1, MPI_DOUBLE_PRECISION, 0, MPI_COMM_WORLD, ierr)
         call mpi_bcast(soap_turbo_hypers(i)%basis, 64, MPI_CHARACTER, 0, MPI_COMM_WORLD, ierr)

--- a/src/types.f90
+++ b/src/types.f90
@@ -76,6 +76,7 @@ module types
     character*32 :: scaling_mode = "polynomial"
     character*8, allocatable :: species_types(:)
     logical :: compress_soap = .false., has_vdw = .false.,&
+               do_linear_energies = .false., do_linear_forces = .false., &
          & has_core_electron_be=.false., has_local_properties = .false.
     type(local_property_soap_turbo), allocatable :: local_property_models(:)
   end type soap_turbo
@@ -171,7 +172,8 @@ module types
                do_pair_distribution = .false., do_structure_factor = .false., do_xrd = .false., do_nd = .false., &
                write_xrd = .false., write_nd = .false., structure_factor_matrix = .true., &
                structure_factor_matrix_forces = .true., write_exp = .true., valid_pdf = .false., valid_sf = .false., &
-               valid_xrd = .false., valid_nd = .false., mc_planes_restrict_to_polyhedron = .false.
+               valid_xrd = .false., valid_nd = .false., mc_planes_restrict_to_polyhedron = .false., &
+               kernel_linearization = .false.
 
     integer :: mc_n_planes = 0
     real*8, allocatable :: mc_max_dist_to_planes(:), mc_planes(:) ! Final index indexes the planes in first index

--- a/tools/kernel_linearization/README.md
+++ b/tools/kernel_linearization/README.md
@@ -8,24 +8,27 @@ Author(s): Patricia Hernandez Leon
 Related files included in TurboGAP:
 
 - src/kernel_linearization.f90
+
     **kernel_linearization** module containing all subroutines and functions related to kernel
     linearization, both for calculations and testing purposes.
 
 - tools/kernel_linearization/get_linearized_sparse_model.f90
+
     Given a trained potential, **get_linearized_sparse_model.f90** script checks whether kernel
     linearization is favourable and returns the necessary files to perform it with TurboGAP.
     Current implementation supports only energies (forces are on the way).
     It uses the **kernel_linearization** module included in TurboGAP.
 
-- tools/kernel_linearization/test_kernel_linearization_module.f90
-- tools/kernel_linearization/test_kernel_linearization_workflow.sh
+- *tools/kernel_linearization/tests/test_kernel_linearization_module.f90
+- *tools/kernel_linearization/tests/test_kernel_linearization_workflow.sh
+
 
 ## Using kernel linearization with TurboGAP
 
 (1) Get the linearized version of the sparse contribution by running **get_linearized_sparse_model.f90**
     script (see **Running the tool** section). 
     The output file(s) are placed on the same folder as the given trained GAP: 
-    [alphas file]\_linear.dat (energies), [descriptor file]\_linear (forces)
+    
 
 (2) Activate kernel linearization support when running TurboGAP by adding the following line to the 
     input file:
@@ -34,23 +37,26 @@ Related files included in TurboGAP:
 
 
 ## Running the tool 
-### (a.k.a. getting the linearized sparse contribution)
+#### (a.k.a. getting the linearized sparse contribution)
+
 
 You need to have a **gap_files** directory with your GAP potential, check first tools/quip_xml_to_gap
 otherwise.
 
 Compile the following code from the directory containing your gap_files folder:
 
-    gfortran -c /turbogap/source/directory/src/kernel_linearization.f90
+    gfortran -c /turbogap/source/directory/src/kernel_linearization.f90 -O3
 
-    gfortran -o get_linearized_sparse_model kernel_linearization.o /turbogap/source/directory/tools/kernel_linearization/get_linearized_sparse_model.f90 -lblas
+    gfortran -o get_linearized_sparse_model kernel_linearization.o /turbogap/source/directory/tools/kernel_linearization/get_linearized_sparse_model.f90 -O3 -lblas
 
-Note that `/turbogap/source/directory` is the directory where you have your **TurboGAP** installation.
+Note that `/turbogap/source/directory` is the directory where you have your **TurboGAP** installation. Moreover, use the same optimization flags as in TurboGAP or the timing will not be reliable.
+
 To get the linearized sparse contribution, just run:
 
     ./get_linearized_sparse_model [path to your GAP file]
 
+If there is a speed-up in the calculation, the tool will generate the output file(s): [alphas file]\_linear.dat (energies), [descriptor file]\_linear (forces). These are placed on your gap_files directory.
 
-## Example/tests
+If you want to avoid any checks and just get the files, set `do_check = .false.` in the code before following the previous steps.
 
 

--- a/tools/kernel_linearization/README.md
+++ b/tools/kernel_linearization/README.md
@@ -1,0 +1,56 @@
+# Kernel linearization
+
+Author(s): Patricia Hernandez Leon
+
+
+## Documentation
+
+Related files included in TurboGAP:
+
+- src/kernel_linearization.f90
+    **kernel_linearization** module containing all subroutines and functions related to kernel
+    linearization, both for calculations and testing purposes.
+
+- tools/kernel_linearization/get_linearized_sparse_model.f90
+    Given a trained potential, **get_linearized_sparse_model.f90** script checks whether kernel
+    linearization is favourable and returns the necessary files to perform it with TurboGAP.
+    Current implementation supports only energies (forces are on the way).
+    It uses the **kernel_linearization** module included in TurboGAP.
+
+- tools/kernel_linearization/test_kernel_linearization_module.f90
+- tools/kernel_linearization/test_kernel_linearization_workflow.sh
+
+## Using kernel linearization with TurboGAP
+
+(1) Get the linearized version of the sparse contribution by running **get_linearized_sparse_model.f90**
+    script (see **Running the tool** section). 
+    The output file(s) are placed on the same folder as the given trained GAP: 
+    [alphas file]\_linear.dat (energies), [descriptor file]\_linear (forces)
+
+(2) Activate kernel linearization support when running TurboGAP by adding the following line to the 
+    input file:
+
+    kernel_linearization = .true.
+
+
+## Running the tool 
+### (a.k.a. getting the linearized sparse contribution)
+
+You need to have a **gap_files** directory with your GAP potential, check first tools/quip_xml_to_gap
+otherwise.
+
+Compile the following code from the directory containing your gap_files folder:
+
+    gfortran -c /turbogap/source/directory/src/kernel_linearization.f90
+
+    gfortran -o get_linearized_sparse_model kernel_linearization.o /turbogap/source/directory/tools/kernel_linearization/get_linearized_sparse_model.f90 -lblas
+
+Note that `/turbogap/source/directory` is the directory where you have your **TurboGAP** installation.
+To get the linearized sparse contribution, just run:
+
+    ./get_linearized_sparse_model [path to your GAP file]
+
+
+## Example/tests
+
+

--- a/tools/kernel_linearization/README.md
+++ b/tools/kernel_linearization/README.md
@@ -7,26 +7,23 @@ Author(s): Patricia Hernandez Leon
 
 Related files included in TurboGAP:
 
-- src/kernel_linearization.f90
+- src/kernel_linearization.f90 \
 
-    **kernel_linearization** module containing all subroutines and functions related to kernel
+    [**kernel_linearization** module](/src/kernel_linearization.f90) containing all subroutines and functions related to kernel
     linearization, both for calculations and testing purposes.
 
-- tools/kernel_linearization/get_linearized_sparse_model.f90
+- tools/kernel_linearization/get_linearized_sparse_model.f90 \
 
     Given a trained potential, **get_linearized_sparse_model.f90** script checks whether kernel
     linearization is favourable and returns the necessary files to perform it with TurboGAP.
     Current implementation supports only energies (forces are on the way).
     It uses the **kernel_linearization** module included in TurboGAP.
 
-- *tools/kernel_linearization/tests/test_kernel_linearization_module.f90
-- *tools/kernel_linearization/tests/test_kernel_linearization_workflow.sh
-
 
 ## Using kernel linearization with TurboGAP
 
 (1) Get the linearized version of the sparse contribution by running **get_linearized_sparse_model.f90**
-    script (see **Running the tool** section). 
+    script (see [**Running the tool**]{#running-the-tool} section). 
     The output file(s) are placed on the same folder as the given trained GAP: 
     
 

--- a/tools/kernel_linearization/README.md
+++ b/tools/kernel_linearization/README.md
@@ -7,12 +7,12 @@ Author(s): Patricia Hernandez Leon
 
 Related files included in TurboGAP:
 
-- src/kernel_linearization.f90 \
+- src/kernel_linearization.f90  
 
     [**kernel_linearization** module](/src/kernel_linearization.f90) containing all subroutines and functions related to kernel
     linearization, both for calculations and testing purposes.
 
-- tools/kernel_linearization/get_linearized_sparse_model.f90 \
+- tools/kernel_linearization/get_linearized_sparse_model.f90  
 
     Given a trained potential, **get_linearized_sparse_model.f90** script checks whether kernel
     linearization is favourable and returns the necessary files to perform it with TurboGAP.
@@ -23,7 +23,7 @@ Related files included in TurboGAP:
 ## Using kernel linearization with TurboGAP
 
 (1) Get the linearized version of the sparse contribution by running **get_linearized_sparse_model.f90**
-    script (see [**Running the tool**]{#running-the-tool} section). 
+    script (see [**Running the tool**](#running-the-tool) section). 
     The output file(s) are placed on the same folder as the given trained GAP: 
     
 
@@ -37,7 +37,7 @@ Related files included in TurboGAP:
 #### (a.k.a. getting the linearized sparse contribution)
 
 
-You need to have a **gap_files** directory with your GAP potential, check first tools/quip_xml_to_gap
+You need to have a **gap_files** directory with your GAP potential, check first [quip_xml_to_gap section](/tools/quip_xml_to_gap)
 otherwise.
 
 Compile the following code from the directory containing your gap_files folder:

--- a/tools/kernel_linearization/get_linearized_sparse_model.f90
+++ b/tools/kernel_linearization/get_linearized_sparse_model.f90
@@ -1,0 +1,271 @@
+! HND XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+! HND X
+! HND X   TurboGAP
+! HND X
+! HND X   TurboGAP is copyright (c) 2019-2023, Miguel A. Caro and others
+! HND X
+! HND X   TurboGAP is published and distributed under the
+! HND X      Academic Software License v1.0 (ASL)
+! HND X
+! HND X   This file, get_linearized_sparse_model.f90, is copyright (c) 2019-2024, Miguel A. Caro and
+! HND X   Patricia Hernandez-Leon
+! HND X
+! HND X   TurboGAP is distributed in the hope that it will be useful for non-commercial
+! HND X   academic research, but WITHOUT ANY WARRANTY; without even the implied
+! HND X   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+! HND X   ASL for more details.
+! HND X
+! HND X   You should have received a copy of the ASL along with this program
+! HND X   (e.g. in a LICENSE.md file); if not, you can write to the original
+! HND X   licensor, Miguel Caro (mcaroba@gmail.com). The ASL is also published at
+! HND X   http://github.com/gabor1/ASL
+! HND X
+! HND X   When using this software, please cite the following reference:
+! HND X
+! HND X   Miguel A. Caro. Phys. Rev. B 100, 024112 (2019)
+! HND X
+! HND XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+! This program checks whether kernel linearization is faster than usual kernel
+! computation, given a trained GAP with soap_turbo descriptors.
+! If favorable, the program also generates any file related to the linearized
+! model, needed for TurboGAP calculations with kernel linearization support.
+
+program get_linear_model
+
+  use kernel_linearization
+
+  implicit none
+
+  integer :: n_soap, n_linear, n_sparse, n_soap_turbo = 0, zeta, iostatus, i, j, n
+  integer :: n_sites = 1000 ! n. atoms used for timings tests
+  character*1024 :: file_gap, filename, temp
+  character*64 :: keyword
+  character*128 :: cjunk
+  character*1024, allocatable :: file_alphas(:), file_desc(:), file_gap_updated(:)
+  real*8, allocatable :: zetas(:), alphas(:), alphas_linear(:)
+  real*8, allocatable :: Qs(:,:), Ms_linear(:,:)
+  logical :: do_linear = .false.
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Parameters that should be provided by the user
+! path to the GAP file
+  call get_command_argument(1, file_gap)
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+! Extract the info about zeta, alphas file and descriptor files
+  call read_gap_hypers(file_gap, n_soap_turbo, zetas, file_alphas, file_desc)
+
+  do n = 1, n_soap_turbo
+    write(*,*) n
+!   Check that zeta is integer, otherwise continue
+    if( dabs(zetas(n) - dfloat(int(zetas(n)))) < 1.d-5 )then
+      zeta = int(zetas(n))
+    else
+      continue
+    end if
+!   Get alphas, sparse descriptors and their size
+!   Here size of Qs is (1:n_soap, 1:n_sparse)
+    call read_alphas_and_descriptors(file_desc(n), file_alphas(n), n_sparse, n_soap, alphas, Qs)
+    write(*,*) file_desc(n)
+!   Compute the size of the linearized model
+    n_linear = 1
+    do i = 1, zeta
+      n_linear = n_linear*(n_soap + i - 1)/i
+    end do
+    write(*,*) "n_sites = ", n_sites
+    write(*,*) "zeta = ", zeta
+    write(*,*) "n_sparse = ", size(Qs, 1)
+    write(*,*) "n_soap = ", size(Qs, 2)
+    write(*,*) "n_linear = ", n_linear
+
+!   Check whether kernel linearization is a better option
+    do_linear = check_kernel_vs_linear(zeta, n_sites, n_sparse, n_soap, n_linear, .true.)
+
+!   Compute the linearized sparse contributions if favourable
+    if( .true. )then
+!     ENERGIES
+      alphas_linear = get_linearized_sparse(zeta, alphas, transpose(Qs))
+!     save them
+      filename = trim(file_alphas(n))
+      filename = filename(1:29) // "_linear.dat"
+      open(unit=10, file=filename, status="unknown")
+      do i = 1, n_linear
+        write(10,*) alphas_linear(i), 1.
+      end do
+      close(10)
+
+!     FORCES
+      allocate( Ms_linear(1:n_soap,1:n_linear) )
+      Ms_linear = 1.d0
+!      Ms_linear = get_linearized_sparse_forces(zeta, alphas, Qs)
+!     add the file for forces contributions
+      filename = trim(file_desc(n)) // "_linear"
+      open(unit=10, file=filename, status="unknown")
+      do i = 1, n_linear
+        do j = 1, n_soap
+          write(10,*) Ms_linear(j, i)
+        end do
+      end do
+      close(10)
+
+    end if
+
+  end do
+
+
+contains
+!**************************************************************************
+!
+! This subroutine is a much shorter version of src/read_files.f90 subroutine
+! with same name, modified to only read the information of soap_turbo descriptors.
+! It only looks for the zetas as well as filenames of alphas, descriptors
+!
+  subroutine read_gap_hypers(file_gap, n_soap_turbo, zeta, file_alphas, file_desc)
+
+    implicit none
+
+!   Input variables
+    character(len=*), intent(in) :: file_gap
+!   Output variables
+    real*8, allocatable, intent(out) :: zeta(:)
+    character(len=*), allocatable, intent(out) :: file_alphas(:), file_desc(:)
+    integer, intent(out) :: n_soap_turbo
+!   Internal variables
+    integer :: iostatus
+    character*64 :: keyword, cjunk
+    character*1 :: keyword_first
+
+    open(unit=10, file=file_gap, status="old", iostat=iostatus)
+!   Look for the number of instances of each GAP
+    n_soap_turbo = 0
+    iostatus = 0
+    do while(iostatus==0)
+      read(10, *, iostat=iostatus) keyword
+      keyword = trim(keyword)
+      if(iostatus/=0)then
+        exit
+      end if
+      keyword_first = keyword(1:1)
+      if(keyword_first=='#' .or. keyword_first=='!')then
+        continue
+      else if(keyword=='gap_beg')then
+        backspace(10)
+        read(10, *, iostat=iostatus) cjunk, keyword
+        if( keyword == "soap_turbo" )then
+          n_soap_turbo = n_soap_turbo + 1
+        end if
+      end if
+    end do
+!   Allocate the variables
+    if( n_soap_turbo > 0 )then
+      allocate( zeta(1:n_soap_turbo) )
+      allocate( file_alphas(1:n_soap_turbo) )
+      allocate( file_desc(1:n_soap_turbo) )
+    end if
+
+!   Now record the hypers
+    rewind(10)
+    n_soap_turbo = 0
+    iostatus = 0
+    do while(iostatus==0)
+      read(10, *, iostat=iostatus) keyword
+      keyword = trim(keyword)
+      if(iostatus/=0)then
+        exit
+      end if
+      keyword_first = keyword(1:1)
+      if(keyword_first=='#' .or. keyword_first=='!')then
+        continue
+      else if(keyword=='gap_beg')then
+        backspace(10)
+        read(10, *, iostat=iostatus) cjunk, keyword
+!       soap_turbo definitions here
+        if( keyword == "soap_turbo" )then
+          n_soap_turbo = n_soap_turbo + 1
+          iostatus = 0
+          do while( keyword /= "gap_end" .and. iostatus == 0 )
+            read(10, *, iostat=iostatus) keyword
+            if( keyword == "zeta" )then
+              backspace(10)
+              read(10, *, iostat=iostatus) cjunk, cjunk, zeta(n_soap_turbo)
+            else if( keyword == "alphas_sparse" )then
+              backspace(10)
+              read(10, *, iostat=iostatus) cjunk, cjunk, file_alphas(n_soap_turbo)
+            else if( keyword == "desc_sparse" )then
+              backspace(10)
+              read(10, *, iostat=iostatus) cjunk, cjunk, file_desc(n_soap_turbo)
+            end if
+          end do
+        end if
+      end if
+    end do
+    close(10)
+
+  end subroutine
+!**************************************************************************
+
+!**************************************************************************
+!
+! This subroutine is a shorter version of src/read_files.f90 subroutine with
+! same name, which assumes the input is soap_turbo descriptors
+! Note that the dimensions of Qs are changed, i.e., Qs(1:n_sparse, 1:n_soap)
+!
+  subroutine read_alphas_and_descriptors(file_desc, file_alphas, n_sparse, &
+                                         n_soap, alphas, Qs)
+
+    implicit none
+
+!   Input variables
+    character*1024, intent(in) :: file_desc, file_alphas
+!   Output variables
+    real*8, allocatable, intent(out) :: alphas(:), Qs(:,:)
+    integer, intent(out) :: n_sparse, n_soap
+!   Internal variables
+    integer :: i, j, iostatus, unit_number
+
+!   Read alphas to figure out sparse set size
+    open(newunit=unit_number, file=file_alphas, status="old")
+    iostatus = 0
+    n_sparse = -1
+    do while(iostatus == 0)
+      read(unit_number, *, iostat=iostatus)
+      n_sparse = n_sparse + 1
+    end do
+    close(unit_number)
+
+!   Get SOAP descriptor vectors size
+    open(newunit=unit_number, file=file_desc, status="old")
+    iostatus = 0
+    i = -1
+    do while(iostatus == 0)
+      read(unit_number, *, iostat=iostatus)
+      i = i + 1
+    end do
+    n_soap = i / n_sparse
+    close(unit_number)
+
+!   Read descriptor vectors in spare set
+!   Read alphas SOAP
+    allocate( alphas(1:n_sparse) )
+    open(newunit=unit_number, file=file_alphas, status="old")
+    do i = 1, n_sparse
+      read(unit_number, *) alphas(i)
+    end do
+    close(unit_number)
+!   Read sparse set descriptors
+    allocate( Qs(1:n_soap, 1:n_sparse) )
+    open(newunit=unit_number, file=file_desc, status="old")
+    do i = 1, n_sparse
+      do j = 1, n_soap
+        read(unit_number, *) Qs(j, i)
+      end do
+    end do
+    close(unit_number)
+
+  end subroutine
+!**************************************************************************
+
+
+end program get_linear_model

--- a/tools/kernel_linearization/get_linearized_sparse_model.f90
+++ b/tools/kernel_linearization/get_linearized_sparse_model.f90
@@ -37,7 +37,7 @@ program get_linear_model
 
   implicit none
 
-  integer :: n_soap, n_linear, n_sparse, n_soap_turbo = 0, zeta, iostatus, i, j, n
+  integer :: n_soap, n_linear, n_sparse, n_soap_turbo = 0, zeta, iostatus, i, j, n, l
   integer :: n_sites = 1000 ! n. atoms used for timings tests
   character*1024 :: file_gap, filename, temp
   character*64 :: keyword
@@ -94,7 +94,8 @@ program get_linear_model
       alphas_linear = get_linearized_sparse(zeta, alphas, transpose(Qs))
 !     save them
       filename = trim(file_alphas(n))
-      filename = filename(1:29) // "_linear.dat"
+      l = len(filename) - 4
+      filename = filename(1:l) // "_linear.dat"
       open(unit=10, file=filename, status="unknown")
       do i = 1, n_linear
         write(10,*) alphas_linear(i), 1.

--- a/tools/kernel_linearization/get_linearized_sparse_model.f90
+++ b/tools/kernel_linearization/get_linearized_sparse_model.f90
@@ -53,6 +53,7 @@ program get_linear_model
   call get_command_argument(1, file_gap)
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  write(*,*) 'Checking kernel linearization ...'
 
 ! Extract the info about zeta, alphas file and descriptor files
   call read_gap_hypers(file_gap, n_soap_turbo, zetas, file_alphas, file_desc)
@@ -68,7 +69,6 @@ program get_linear_model
 !   Get alphas, sparse descriptors and their size
 !   Here size of Qs is (1:n_soap, 1:n_sparse)
     call read_alphas_and_descriptors(file_desc(n), file_alphas(n), n_sparse, n_soap, alphas, Qs)
-    write(*,*) file_desc(n)
 !   Compute the size of the linearized model
     n_linear = 1
     do i = 1, zeta
@@ -89,6 +89,7 @@ program get_linear_model
 
 !   Compute the linearized sparse contributions if favourable
     if( do_linear )then
+      write(*,*) 'Getting linearized sparse contribution ...'
 !     ENERGIES
       alphas_linear = get_linearized_sparse(zeta, alphas, transpose(Qs))
 !     save them

--- a/tools/kernel_linearization/get_linearized_sparse_model.f90
+++ b/tools/kernel_linearization/get_linearized_sparse_model.f90
@@ -45,7 +45,7 @@ program get_linear_model
   character*1024, allocatable :: file_alphas(:), file_desc(:), file_gap_updated(:)
   real*8, allocatable :: zetas(:), alphas(:), alphas_linear(:)
   real*8, allocatable :: Qs(:,:), Ms_linear(:,:)
-  logical :: do_linear = .false.
+  logical :: do_check = .true., do_linear = .false.
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Parameters that should be provided by the user
@@ -81,10 +81,14 @@ program get_linear_model
     write(*,*) "n_linear = ", n_linear
 
 !   Check whether kernel linearization is a better option
-    do_linear = check_kernel_vs_linear(zeta, n_sites, n_sparse, n_soap, n_linear, .true.)
+    if( do_check )then
+      do_linear = check_kernel_vs_linear(zeta, n_sites, n_sparse, n_soap, n_linear, .true.)
+    else
+      do_linear = .true.
+    end if
 
 !   Compute the linearized sparse contributions if favourable
-    if( .true. )then
+    if( do_linear )then
 !     ENERGIES
       alphas_linear = get_linearized_sparse(zeta, alphas, transpose(Qs))
 !     save them


### PR DESCRIPTION
Adds the option to use linearized kernels for both energies and forces calculations. It includes a script to compute the linearized alphas, required as a pre-processing step.

Tested both on local machine and on CSC Puhti.